### PR TITLE
Fix collsion box of gate slot

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,0 +1,17 @@
+name: luacheck
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: apt
+      run: sudo apt-get install -y luarocks
+    - name: luacheck install
+      run: luarocks install --local luacheck
+    - name: luacheck run
+      run: $HOME/.luarocks/bin/luacheck ./

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,26 @@
+std = "luajit+minetest"
+unused_args = false
+
+stds.minetest = {
+	read_globals = {
+		"DIR_DELIM",
+		"minetest",
+		"dump",
+		"vector",
+		"nodeupdate",
+		"VoxelManip",
+		"VoxelArea",
+		"PseudoRandom",
+		"ItemStack",
+		"default",
+		table = {
+			fields = {
+				"copy",
+			},
+		},
+	}
+}
+
+globals = {
+	"castle_gates",
+}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,4 +23,8 @@ stds.minetest = {
 
 globals = {
 	"castle_gates",
+	"castle_masonry",
+	"doc",
+	"doors",
+	"xpanes",
 }

--- a/doc.lua
+++ b/doc.lua
@@ -7,44 +7,85 @@ end
 local S = minetest.get_translator("castle_gates")
 
 castle_gates.doc.portcullis_bars_longdesc = S("Heavy wooden bars designed to prevent entry even to siege equipment.")
-castle_gates.doc.portcullis_bars_usagehelp = S("Place these bars in a structure together and they will slide as a unified gate when clicked on.")
+castle_gates.doc.portcullis_bars_usagehelp = S(
+	"Place these bars in a structure together and they will slide as a unified gate when clicked on."
+)
 
-castle_gates.doc.portcullis_bars_bottom_longdesc = S("The bottom edge of a portcullis gate, with knobs to lock securely into the floor.")
-castle_gates.doc.portcullis_bars_bottom_usagehelp = S("This block can be used to define the edge of a portcullius that meets up with another gate, should you have an arrangement like that. Otherwise it's just decorative.")
+castle_gates.doc.portcullis_bars_bottom_longdesc = S(
+	"The bottom edge of a portcullis gate, with knobs to lock securely into the floor."
+)
+castle_gates.doc.portcullis_bars_bottom_usagehelp = S(
+	"This block can be used to define the edge of a portcullius that meets up with another gate, should you have " ..
+	"an arrangement like that. Otherwise it's just decorative."
+)
 
 castle_gates.doc.gate_panel_longdesc = S("A basic gate panel.")
-castle_gates.doc.gate_panel_usagehelp = S("This gate segment will move in unison with adjoining gate segments when right-clicked.")
+castle_gates.doc.gate_panel_usagehelp = S(
+	"This gate segment will move in unison with adjoining gate segments when right-clicked."
+)
 
 castle_gates.doc.gate_edge_longdesc = S("A gate panel with a defined edge.")
-castle_gates.doc.gate_edge_usagehelp = S("The darkened edge of this panel marks the edge of the gate it's a part of. You can use these when building double doors to ensure the two parts swing separately, for example. Note that edges aren't strictly necessary for gates that stand alone.")
+castle_gates.doc.gate_edge_usagehelp = S(
+	"The darkened edge of this panel marks the edge of the gate it's a part of. " ..
+	"You can use these when building double doors to ensure the two parts swing separately, " ..
+	"for example. Note that edges aren't strictly necessary for gates that stand alone."
+)
 
 castle_gates.doc.gate_edge_handle_longdesc = S("A gate edge with a handle.")
-castle_gates.doc.gate_edge_handle_usagehelp = S("The handle is basically decorative, a door this size can be swung by clicking anywhere on it. But the darkened edge of this panel is useful for defining the edge of a gate when it abuts a partner to the side.")
+castle_gates.doc.gate_edge_handle_usagehelp = S(
+	"The handle is basically decorative, a door this size can be swung by clicking anywhere on it. " ..
+	"But the darkened edge of this panel is useful for defining the edge of a gate when it abuts a partner to the side."
+)
 
 castle_gates.doc.gate_hinge_longdesc = S("A hinged gate segment that allows a gate to swing.")
-castle_gates.doc.gate_hinge_usagehelp = S("If you have more than one hinge in your gate, make sure the hinges line up correctly otherwise the gate will not be able to swing. The hinge is the protruding block along the edge of the gate panel.")
+castle_gates.doc.gate_hinge_usagehelp = S(
+	"If you have more than one hinge in your gate, make sure the hinges line up correctly otherwise the gate will " ..
+	"not be able to swing. The hinge is the protruding block along the edge of the gate panel."
+)
 
 castle_gates.doc.gate_slot_longdesc = S("A block with a slot to allow an adjacent sliding gate through.")
-castle_gates.doc.gate_slot_usagehelp = S("This block is designed to extend into a neighboring node that a sliding gate passes through, to provide a tight seal for the gate to move through without allowing anything else to squeeze in.")
+castle_gates.doc.gate_slot_usagehelp = S(
+	"This block is designed to extend into a neighboring node that a sliding gate passes through, to provide a " ..
+	"tight seal for the gate to move through without allowing anything else to squeeze in."
+)
 
-castle_gates.doc.gate_slot_reverse_longdesc = S("A block that extends into an adjacent node to provide a tight seal for a large gate.")
-castle_gates.doc.gate_slot_reverse_usagehelp = S("Two nodes cannot occupy the same space, but this block extends into a neighboring node's space to allow for gates to form a tight seal. It can be used with sliding gates or swinging gates.")
+castle_gates.doc.gate_slot_reverse_longdesc = S(
+	"A block that extends into an adjacent node to provide a tight seal for a large gate."
+)
+castle_gates.doc.gate_slot_reverse_usagehelp = S(
+	"Two nodes cannot occupy the same space, but this block extends into a neighboring node's space to allow " ..
+	"for gates to form a tight seal. It can be used with sliding gates or swinging gates."
+)
 
 doc.add_category("castle_gates",
 {
 	name = S("Gates"),
-	description = S("Gates are large multi-node constructions that swing on hinges or slide out of the way when triggered."),
+	description = S(
+		"Gates are large multi-node constructions that swing on hinges or slide out of the way when triggered."
+	),
 	build_formspec = doc.entry_builders.text_and_gallery,
 })
 
 doc.add_entry("castle_gates", "construction", {
 	name = S("Gate construction"),
-	data = { text =
-S("Gates are multi-node constructions, usually (though not always) consisting of multiple node types that fit together into a unified whole. The orientation of gate nodes is significant, so a screwdriver will be a helpful tool when constructing gates."
-.."\n\n"..
-"A gate's extent is determined by a \"flood fill\" operation. When you trigger a gate block, all compatible neighboring blocks will be considered part of the same structure and will move in unison. Only gate blocks that are aligned with each other will be considered part of the same gate. If you wish to build adjoining gates (for example, a large pair of double doors that meet in the center) you'll need to make use of gate edge blocks to prevent it all from being considered one big door. Note that if your gate does not abut any other gates you don't actually need to define its edges this way - you don't have to use edge blocks in this case."
-.."\n\n"..
-"If a gate has no hinge nodes it will be considered a sliding gate. When triggered, the gate code will search for a direction that the gate can slide in and will move it in that direction at a rate of one block-length per second. Once it reaches an obstruction it will stop, and when triggered again it will try sliding in the opposite direction."
-.."\n\n"..
-"If a gate has hinge nodes then triggering it will cause the gate to try swinging around the hinge. If the gate has multiple hinges and they don't line up properly the gate will be unable to move. Note that the gate can only exist in 90-degree increments of orientation, but the gate still looks for obstructions in the region it is swinging through and will not swing if there's something in the way.")
-}})
+	data = {text = S(
+		"Gates are multi-node constructions, usually (though not always) consisting of multiple node types that fit " ..
+		"together into a unified whole. The orientation of gate nodes is significant, so a screwdriver will be a " ..
+		"helpful tool when constructing gates.\n\n" ..
+		"A gate's extent is determined by a \"flood fill\" operation. When you trigger a gate block, all compatible " ..
+		"neighboring blocks will be considered part of the same structure and will move in unison. Only gate blocks " ..
+		"that are aligned with each other will be considered part of the same gate. If you wish to build adjoining " ..
+		"gates (for example, a large pair of double doors that meet in the center) you'll need to make use of gate " ..
+		"edge blocks to prevent it all from being considered one big door. Note that if your gate does not abut any" ..
+		" other gates you don't actually need to define its edges this way - you don't have to use edge blocks in " ..
+		"this case.\n\n" ..
+		"If a gate has no hinge nodes it will be considered a sliding gate. When triggered, the gate code will " ..
+		"search for a direction that the gate can slide in and will move it in that direction at a rate of one " ..
+		"block-length per second. Once it reaches an obstruction it will stop, and when triggered again it will " ..
+		"try sliding in the opposite direction.\n\n" ..
+		"If a gate has hinge nodes then triggering it will cause the gate to try swinging around the hinge. " ..
+		"If the gate has multiple hinges and they don't line up properly the gate will be unable to move. " ..
+		"Note that the gate can only exist in 90-degree increments of orientation, but the gate still looks for " ..
+		"obstructions in the region it is swinging through and will not swing if there's something in the way."
+	)}
+})

--- a/doors.lua
+++ b/doors.lua
@@ -29,7 +29,7 @@ if minetest.get_modpath("doors") then
 			{"default:steel_ingot", ""},
 		}
 	end
-	
+
 	doors.register("castle_gates:jail_door", {
 		tiles = {{ name = "castle_door_jail.png", backface_culling = true }},
 		description = S("Jail Door"),
@@ -40,7 +40,7 @@ if minetest.get_modpath("doors") then
 		sound_close = "doors_steel_door_close",
 		recipe = door_recipe,
 	})
-	
+
 	minetest.register_alias("castle:oak_door_a", "castle_gates:oak_door_a")
 	minetest.register_alias("castle:oak_door_b", "castle_gates:oak_door_b")
 	minetest.register_alias("castle:jail_door_a", "castle_gates:jail_door_a")

--- a/gate_functions.lua
+++ b/gate_functions.lua
@@ -1,5 +1,3 @@
-local MP = minetest.get_modpath(minetest.get_current_modname())
-
 -- Given a facedir, returns a set of all the corresponding directions
 local get_dirs = function(facedir)
 	local dirs = {}
@@ -8,7 +6,7 @@ local get_dirs = function(facedir)
 		{x=0, y=0, z=-1},
 		{x=1, y=0, z=0},
 		{x=-1, y=0, z=0},
-		{x=0, y=-1, z=0}}	
+		{x=0, y=-1, z=0}}
 	dirs.back = minetest.facedir_to_dir(facedir)
 	dirs.top = top[math.floor(facedir/4)]
 	dirs.right = {
@@ -35,8 +33,8 @@ end
 
 -- Given a hinge definition, turns it into an axis and placement that can be used by the door rotation.
 local interpret_hinge = function(hinge_def, pos, node_dirs)
-	local axis = dir_to_axis(node_dirs[hinge_def.axis]) 
-	
+	local axis = dir_to_axis(node_dirs[hinge_def.axis])
+
 	local placement
 	if type(hinge_def.offset) == "string" then
 		placement = vector.add(pos, node_dirs[hinge_def.offset])
@@ -61,16 +59,22 @@ end
 
 local facedir_rotate = {
 	['x'] = {
-		[-1] = {[0]=4, 5, 6, 7, 22, 23, 20, 21, 0, 1, 2, 3, 13, 14, 15, 12, 19, 16, 17, 18, 10, 11, 8, 9}, -- 270 degrees
-		[1] = {[0]=8, 9, 10, 11, 0, 1, 2, 3, 22, 23, 20, 21, 15, 12, 13, 14, 17, 18, 19, 16, 6, 7, 4, 5}, -- 90 degrees
+		-- 270 degrees
+		[-1] = {[0]=4, 5, 6, 7, 22, 23, 20, 21, 0, 1, 2, 3, 13, 14, 15, 12, 19, 16, 17, 18, 10, 11, 8, 9},
+		-- 90 degrees
+		[1] = {[0]=8, 9, 10, 11, 0, 1, 2, 3, 22, 23, 20, 21, 15, 12, 13, 14, 17, 18, 19, 16, 6, 7, 4, 5},
 	},
 	['y'] = {
-		[-1] = {[0]=3, 0, 1, 2, 19, 16, 17, 18, 15, 12, 13, 14, 7, 4, 5, 6, 11, 8, 9, 10, 21, 22, 23, 20}, -- 270 degrees
-		[1] = {[0]=1, 2, 3, 0, 13, 14, 15, 12, 17, 18, 19, 16, 9, 10, 11, 8, 5, 6, 7, 4, 23, 20, 21, 22}, -- 90 degrees
+		-- 270 degrees
+		[-1] = {[0]=3, 0, 1, 2, 19, 16, 17, 18, 15, 12, 13, 14, 7, 4, 5, 6, 11, 8, 9, 10, 21, 22, 23, 20},
+		-- 90 degrees
+		[1] = {[0]=1, 2, 3, 0, 13, 14, 15, 12, 17, 18, 19, 16, 9, 10, 11, 8, 5, 6, 7, 4, 23, 20, 21, 22},
 	},
 	['z'] = {
-		[-1] = {[0]=16, 17, 18, 19, 5, 6, 7, 4, 11, 8, 9, 10, 0, 1, 2, 3, 20, 21, 22, 23, 12, 13, 14, 15}, -- 270 degrees
-		[1] = {[0]=12, 13, 14, 15, 7, 4, 5, 6, 9, 10, 11, 8, 20, 21, 22, 23, 0, 1, 2, 3, 16, 17, 18, 19}, -- 90 degrees
+		-- 270 degrees
+		[-1] = {[0]=16, 17, 18, 19, 5, 6, 7, 4, 11, 8, 9, 10, 0, 1, 2, 3, 20, 21, 22, 23, 12, 13, 14, 15},
+		-- 90 degrees
+		[1] = {[0]=12, 13, 14, 15, 7, 4, 5, 6, 9, 10, 11, 8, 20, 21, 22, 23, 0, 1, 2, 3, 16, 17, 18, 19},
 	}
 }
 	--90 degrees CW about x-axis: (x, y, z) -> (x, -z, y)
@@ -92,7 +96,7 @@ local rotate_pos = function(axis, direction, pos)
 		else
 			return {x= pos.z, y= pos.y, z= -pos.x}
 		end
-	else	
+	else
 		if direction < 0 then
 			return {x= -pos.y, y= pos.x, z= pos.z}
 		else
@@ -115,12 +119,17 @@ end
 
 
 local get_door_layout = function(pos, facedir, player)
-	if facedir > 23 then return nil end -- A bug in another mod once resulted in bad param2s being written to nodes, this will at least prevent crashes if something like that happens again.
+	if facedir > 23 then
+		--[[ A bug in another mod once resulted in bad param2s being written to nodes, this will at least prevent
+		     crashes if something like that happens again.]]
+		return nil
+	end
 
 	-- This method does a flood-fill looking for all nodes that meet the following criteria:
 	-- belongs to a "castle_gate" group
 	-- has the same "back" direction as the initial node
-	-- is accessible via up, down, left or right directions unless one of those directions goes through an edge that one of the two nodes has marked as a gate edge
+	-- is accessible via up, down, left or right directions unless one of those directions goes through an edge that
+	-- one of the two nodes has marked as a gate edge
 	local door = {}
 
 	door.all = {}
@@ -132,8 +141,9 @@ local get_door_layout = function(pos, facedir, player)
 	local to_test = {}
 	local tested = {}
 	local can_slide_to = {}
-	
-	local castle_gate_group_value -- this will be populated from the first gate node we encounter, which will be the one that was clicked on
+
+	-- this will be populated from the first gate node we encounter, which will be the one that was clicked on
+	local castle_gate_group_value
 
 	local player_has_bypass = minetest.check_player_privs(player, "protection_bypass")
 
@@ -147,22 +157,25 @@ local get_door_layout = function(pos, facedir, player)
 			--array is next to unloaded nodes, too dangerous to do anything. Abort.
 			return nil
 		end
-		
+
 		if not player_has_bypass and minetest.is_protected(test_pos, player:get_player_name()) then
 			door.contains_protected_node = true
 		end
-		
+
 		local test_node_def = minetest.registered_nodes[test_node.name]
 		if test_node_def.buildable_to then
 			can_slide_to[test_pos_hash] = true
 		end
-		
-		if test_node_def.paramtype2 == "facedir" and test_node.param2 <= 23 then -- prospective door nodes need to be of type facedir and have a valid param2
+
+		if test_node_def.paramtype2 == "facedir" and test_node.param2 <= 23 then
+			-- prospective door nodes need to be of type facedir and have a valid param2
 			local test_node_dirs = get_dirs(test_node.param2)
-			local coplanar = vector.equals(test_node_dirs.back, door.directions.back) -- the "back" vector needs to point in the same direction as the rest of the door
-			
+			-- the "back" vector needs to point in the same direction as the rest of the door
+			local coplanar = vector.equals(test_node_dirs.back, door.directions.back)
+
 			if castle_gate_group_value == nil and test_node_def.groups.castle_gate ~= nil then
-				castle_gate_group_value = test_node_def.groups.castle_gate -- read the group value from the first gate node encountered
+				-- read the group value from the first gate node encountered
+				castle_gate_group_value = test_node_def.groups.castle_gate
 			end
 
 			if coplanar and test_node_def.groups.castle_gate == castle_gate_group_value then
@@ -172,20 +185,27 @@ local get_door_layout = function(pos, facedir, player)
 					local axis, placement = interpret_hinge(test_node_def._gate_hinge, test_pos, test_node_dirs)
 					if door.hinge == nil then -- this is the first hinge we've encountered.
 						door.hinge = {axis=axis, placement=placement}
-						door.directions = test_node_dirs -- force the door as a whole to use the same reference frame as the first hinge
-					elseif door.hinge.axis ~= axis then -- there was a previous hinge. Do they rotate on the same axis?
-						return nil -- Misaligned hinge axes, door cannot rotate.
+						-- force the door as a whole to use the same reference frame as the first hinge
+						door.directions = test_node_dirs
+					elseif door.hinge.axis ~= axis then
+						-- there was a previous hinge. Do they rotate on the same axis?
+						-- Misaligned hinge axes, door cannot rotate.
+						return nil
 					else
 						local axis_dir = {x=0, y=0, z=0}
 						axis_dir[axis] = 1
-						local displacement = vector.normalize(vector.subtract(placement, door.hinge.placement)) -- check if this new hinge is displaced relative to the first hinge on any axis other than the rotation axis
-						if not (vector.equals(displacement, axis_dir) or vector.equals(displacement, vector.multiply(axis_dir, -1))) then
+						-- check if this new hinge is displaced relative to the first hinge on any axis other than the
+						-- rotation axis
+						local displacement = vector.normalize(vector.subtract(placement, door.hinge.placement))
+						if not (vector.equals(displacement, axis_dir) or
+							    vector.equals(displacement, vector.multiply(axis_dir, -1))) then
 							return nil -- Misaligned hinge offset, door cannot rotate.
 						end
 					end
 				end
-				
-				can_slide_to[test_pos_hash] = true -- since this is part of the door, other parts of the door can slide into it
+
+				-- since this is part of the door, other parts of the door can slide into it
+				can_slide_to[test_pos_hash] = true
 
 				local test_directions = {"top", "bottom", "left", "right"}
 				for _, dir in pairs(test_directions) do
@@ -193,51 +213,64 @@ local get_door_layout = function(pos, facedir, player)
 					local adjacent_node = minetest.get_node(adjacent_pos)
 					local adjacent_def = minetest.registered_nodes[adjacent_node.name]
 					local adjacent_pos_hash = minetest.hash_node_position(adjacent_pos)
-					
+
 					if adjacent_def.buildable_to then
 						can_slide_to[adjacent_pos_hash] = true
 					end
-					
-					if test_node_def._gate_edges == nil or not test_node_def._gate_edges[dir] then -- if we ourselves are an edge node, don't look in the direction we're an edge in
-						
-						if tested[adjacent_pos_hash] == nil then -- don't look at nodes that have already been looked at
-							if adjacent_def.paramtype2 == "facedir" then -- all doors are facedir nodes so we can pre-screen some targets
+
+					-- if we ourselves are an edge node, don't look in the direction we're an edge in
+					if test_node_def._gate_edges == nil or not test_node_def._gate_edges[dir] then
+
+						if tested[adjacent_pos_hash] == nil then
+							-- don't look at nodes that have already been looked at
+							if adjacent_def.paramtype2 == "facedir" then
+								-- all doors are facedir nodes so we can pre-screen some targets
 								local edge_points_back_at_test_pos = false
-								-- Look at the adjacent node's definition. If it's got gate edges, check if they point back at us.
+								-- Look at the adjacent node's definition. If it's got gate edges, check if they
+								-- point back at us.
 								if adjacent_def._gate_edges ~= nil then
 									local adjacent_directions = get_dirs(adjacent_node.param2)
-									for dir, val in pairs(adjacent_def._gate_edges) do
-										if vector.equals(vector.add(adjacent_pos, adjacent_directions[dir]), test_pos) then
+									for dir2, _ in pairs(adjacent_def._gate_edges) do
+										if vector.equals(vector.add(adjacent_pos, adjacent_directions[dir2]),
+											             test_pos) then
 											edge_points_back_at_test_pos = true
 											break
 										end
-									end									
+									end
 								end
-								
+
 								if not edge_points_back_at_test_pos then
 									table.insert(to_test, adjacent_pos_hash)
 								end
 							end
 						end
-					end				
+					end
 				end
 			end
 		end
-		
+
 		test_pos = table.remove(to_test)
 		if test_pos ~= nil then
 			test_pos = minetest.get_position_from_hash(test_pos)
 		end
 	end
-	
+
 	if door.hinge == nil then
 		--sliding door, evaluate which directions it can go
 		door.can_slide = {top=true, bottom=true, left=true, right=true}
 		for _,door_node in pairs(door.all) do
-			door.can_slide.top = door.can_slide.top and can_slide_to[minetest.hash_node_position(vector.add(door_node.pos, door.directions.top))]
-			door.can_slide.bottom = door.can_slide.bottom and can_slide_to[minetest.hash_node_position(vector.add(door_node.pos, door.directions.bottom))]
-			door.can_slide.left = door.can_slide.left and can_slide_to[minetest.hash_node_position(vector.add(door_node.pos, door.directions.left))]
-			door.can_slide.right = door.can_slide.right and can_slide_to[minetest.hash_node_position(vector.add(door_node.pos, door.directions.right))]
+			door.can_slide.top = door.can_slide.top and can_slide_to[
+				minetest.hash_node_position(vector.add(door_node.pos, door.directions.top))
+			]
+			door.can_slide.bottom = door.can_slide.bottom and can_slide_to[
+				minetest.hash_node_position(vector.add(door_node.pos, door.directions.bottom))
+			]
+			door.can_slide.left = door.can_slide.left and can_slide_to[
+				minetest.hash_node_position(vector.add(door_node.pos, door.directions.left))
+			]
+			door.can_slide.right = door.can_slide.right and can_slide_to[
+				minetest.hash_node_position(vector.add(door_node.pos, door.directions.right))
+			]
 		end
 	else
 		--rotating door, evaluate which direction it can go. Slightly more complicated.
@@ -248,28 +281,33 @@ local get_door_layout = function(pos, facedir, player)
 
 		door.swings = {}
 
-		for _, direction in pairs({-1, 1}) do 
+		for _, direction in pairs({-1, 1}) do
 			door.swings[direction] = true
 			for _, door_node in pairs(door.all) do
 				origin[axis] = door_node.pos[axis]
-				if not vector.equals(door_node.pos, origin) then -- There's no obstruction if the node is literally located along the rotation axis
+				if not vector.equals(door_node.pos, origin) then
+					-- There's no obstruction if the node is literally located along the rotation axis
 					local newpos = rotate_pos_displaced(door_node.pos, origin, axis, direction)
 					local newnode = minetest.get_node(newpos)
 					local newdef = minetest.registered_nodes[newnode.name]
-					if not newdef.buildable_to then -- check if the destination node is free.
+					if not newdef.buildable_to then
+						-- check if the destination node is free.
 						door.swings[direction] = false
 						break
 					end
-					
+
 					local swing_corner = {} -- the corner of the square "arc" that a Minetest gate swings through
 					local scan_dir
 					swing_corner[axis] = door_node.pos[axis]
 					swing_corner[backfront] = newpos[backfront]
 					swing_corner[leftright] = door_node.pos[leftright]
-					if not (vector.equals(newpos, swing_corner) or vector.equals(door_node.pos, swing_corner)) then -- we're right next to the hinge, no need for further testing
-						scan_dir = vector.direction(newpos, swing_corner) -- get the direction from the new door position toward the swing corner
+					if not (vector.equals(newpos, swing_corner) or vector.equals(door_node.pos, swing_corner)) then
+						-- we're right next to the hinge, no need for further testing
+						-- get the direction from the new door position toward the swing corner
+						scan_dir = vector.direction(newpos, swing_corner)
 						repeat
-							newpos = vector.add(newpos, scan_dir) -- we start with newpos on the destination node, which has already been tested.
+							-- we start with newpos on the destination node, which has already been tested.
+							newpos = vector.add(newpos, scan_dir)
 							if not get_buildable_to(newpos) then
 								door.swings[direction] = false
 							end
@@ -277,7 +315,8 @@ local get_door_layout = function(pos, facedir, player)
 
 						if not (vector.equals(newpos, door_node.pos) or door.swings[direction] == false) then
 							scan_dir = vector.direction(newpos, door_node.pos)
-							newpos = vector.add(newpos, scan_dir) -- the first step here is a freebie since we've already checked swing_corner
+							-- the first step here is a freebie since we've already checked swing_corner
+							newpos = vector.add(newpos, scan_dir)
 							while not (vector.equals(newpos, door_node.pos) or door.swings[direction] == false) do
 								if not get_buildable_to(newpos) then
 									door.swings[direction] = false
@@ -287,13 +326,13 @@ local get_door_layout = function(pos, facedir, player)
 						end
 					end
 				end
-				
+
 				if door.swings[direction] == false then
 					break
 				end
-				
+
 			end
-		end	
+		end
 	end
 	return door
 end
@@ -313,7 +352,7 @@ local rotate_door = function (door, direction)
 
 	local origin = door.hinge.placement
 	local axis = door.hinge.axis
-	
+
 	for _, door_node in pairs(door.all) do
 		door_node.pos = rotate_pos_displaced(door_node.pos, origin, axis, direction)
 		door_node.node.param2 = facedir_rotate[axis][direction][door_node.node.param2]
@@ -334,12 +373,12 @@ castle_gates.trigger_gate = function(pos, node, player)
 	end
 
 	local door = get_door_layout(pos, node.param2, player)
-	
+
 	if door ~= nil then
 		for _, door_node in pairs(door.all) do
 			minetest.set_node(door_node.pos, {name="air"})
 		end
-		
+
 		local door_moved = false
 		if door.can_slide ~= nil then -- this is a sliding door
 			if door.previous_move == "top" and door.can_slide.top then
@@ -355,7 +394,7 @@ castle_gates.trigger_gate = function(pos, node, player)
 				slide_gate(door, "right")
 				door_moved = true
 			end
-			
+
 			if not door_moved then -- reverse door's direction for next time
 				if door.previous_move == "top" and door.can_slide.bottom then
 					door.previous_move = "bottom"
@@ -380,8 +419,8 @@ castle_gates.trigger_gate = function(pos, node, player)
 				door_moved = rotate_door(door, 1)
 			elseif door.previous_move == "widdershins" then
 				door_moved = rotate_door(door, -1)
-			end				
-			
+			end
+
 			if not door_moved then
 				if door.previous_move == "deosil" then
 					door.previous_move = "widdershins"
@@ -395,7 +434,7 @@ castle_gates.trigger_gate = function(pos, node, player)
 			minetest.set_node(door_node.pos, door_node.node)
 			minetest.get_meta(door_node.pos):set_string("previous_move", door.previous_move)
 		end
-		
+
 		if door_moved then
 			minetest.after(1, function(player_name)
 				-- Get current player ObjectRef (nil when gone)
@@ -403,5 +442,5 @@ castle_gates.trigger_gate = function(pos, node, player)
 					minetest.get_player_by_name(player_name))
 			end, player:get_player_name())
 		end
-	end	
+	end
 end

--- a/gate_slots.lua
+++ b/gate_slots.lua
@@ -12,7 +12,7 @@ local get_material_properties = function(material)
 		composition_def = minetest.registered_nodes[material.craft_material]
 		burn_time = minetest.get_craft_result({method="fuel", width=1, items={ItemStack(material.craft_materia)}}).time
 	end
-	
+
 	local tiles = material.tile
 	if tiles == nil then
 		tiles = composition_def.tile
@@ -24,7 +24,7 @@ local get_material_properties = function(material)
 	if desc == nil then
 		desc = composition_def.description
 	end
-	
+
 	return composition_def, burn_time, tiles, desc
 end
 
@@ -49,24 +49,27 @@ castle_gates.register_gate_slot = function(material)
 		paramtype2 = "facedir",
 		groups = composition_def.groups,
 		sounds = composition_def.sounds,
-		
+
 		node_box = {
 			type = "fixed",
 			fixed = {
 				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5}, -- body
 				{-0.5, -0.5, -0.75, 0.5, 0.5, -1.5}, -- bracket
-			}
+			},
 		},
-		
+
 		collision_box = {
 			type = "fixed",
-			fixed = {-0.5, -0.5, -0.5, 0.5, 0.5, 1.5}, -- body
+			fixed = {
+				{-0.5, -0.5, -0.5, 0.5, 0.5, 0.5}, -- body
+				{-0.5, -0.5, -0.75, 0.5, 0.5, -1.5}, -- bracket
+			},
 		},
 	})
-	
+
 	minetest.register_node(mod_name..":"..material.name.."_gate_slot_reverse", {
 		drawtype = "nodebox",
-		description = S("@1 Gate Slot Reverse", desc), 
+		description = S("@1 Gate Slot Reverse", desc),
 		_doc_items_longdesc = castle_gates.doc.gate_slot_reverse_longdesc,
 		_doc_items_usagehelp = castle_gates.doc.gate_slot_reverse_usagehelp,
 		tiles = tile,
@@ -74,21 +77,21 @@ castle_gates.register_gate_slot = function(material)
 		paramtype2 = "facedir",
 		groups = composition_def.groups,
 		sounds = composition_def.sounds,
-		
+
 		node_box = {
 			type = "fixed",
 			fixed = {
 				{-0.5, -0.5, -1.25, 0.5, 0.5, 0.5}, -- body
 			}
 		},
-		
+
 		collision_box = {
 			type = "fixed",
 			fixed = {-0.5, -0.5, -1.25, 0.5, 0.5, 0.5}, -- body
 		},
 	})
-	
-	
+
+
 	minetest.register_craft({
 	output = mod_name..":"..material.name.."_gate_slot 2",
 	recipe = {
@@ -96,7 +99,7 @@ castle_gates.register_gate_slot = function(material)
 		{material.craft_material,"",material.craft_material},
 		},
 	})
-	
+
 	minetest.register_craft({
 		output = mod_name..":"..material.name.."_gate_slot",
 		type = "shapeless",
@@ -107,7 +110,7 @@ castle_gates.register_gate_slot = function(material)
 		type = "shapeless",
 		recipe = {mod_name..":"..material.name.."_gate_slot"},
 	})
-	
+
 	if burn_time > 0 then
 		minetest.register_craft({
 			type = "fuel",
@@ -118,7 +121,7 @@ castle_gates.register_gate_slot = function(material)
 			type = "fuel",
 			recipe = mod_name..":"..material.name.."_gate_slot_reverse",
 			burntime = burn_time * 2,
-		})	
+		})
 	end
 end
 

--- a/gate_slots.lua
+++ b/gate_slots.lua
@@ -7,10 +7,18 @@ local get_material_properties = function(material)
 	local burn_time
 	if material.composition_material ~= nil then
 		composition_def = minetest.registered_nodes[material.composition_material]
-		burn_time = minetest.get_craft_result({method="fuel", width=1, items={ItemStack(material.composition_material)}}).time
+		burn_time = minetest.get_craft_result({
+			method="fuel",
+			width=1,
+			items={ItemStack(material.composition_material)}}
+		).time
 	else
 		composition_def = minetest.registered_nodes[material.craft_material]
-		burn_time = minetest.get_craft_result({method="fuel", width=1, items={ItemStack(material.craft_materia)}}).time
+		burn_time = minetest.get_craft_result({
+			method="fuel",
+			width=1,
+			items={ItemStack(material.craft_materia)}}
+		).time
 	end
 
 	local tiles = material.tile
@@ -32,7 +40,14 @@ local materials
 if minetest.get_modpath("castle_masonry") then
 	materials = castle_masonry.materials
 else
-	materials = {{name="stonebrick", desc=S("Stonebrick"), tile="default_stone_brick.png", craft_material="default:stonebrick"}}
+	materials = {
+		{
+			name="stonebrick",
+			desc=S("Stonebrick"),
+			tile="default_stone_brick.png",
+			craft_material="default:stonebrick"
+		}
+	}
 end
 
 castle_gates.register_gate_slot = function(material)
@@ -125,13 +140,25 @@ castle_gates.register_gate_slot = function(material)
 	end
 end
 
-castle_gates.register_gate_slot_alias = function(old_mod_name, old_material_name, new_mod_name, new_material_name)
-	minetest.register_alias(old_mod_name..":"..old_material_name.."_gate_slot",			new_mod_name..":"..new_material_name.."_gate_slot")
-	minetest.register_alias(old_mod_name..":"..old_material_name.."_gate_slot_reverse",	new_mod_name..":"..new_material_name.."_gate_slot_reverse")
+function castle_gates.register_gate_slot_alias(old_mod_name, old_material_name, new_mod_name, new_material_name)
+	minetest.register_alias(
+		old_mod_name..":"..old_material_name.."_gate_slot",
+		new_mod_name..":"..new_material_name.."_gate_slot"
+	)
+	minetest.register_alias(
+		old_mod_name..":"..old_material_name.."_gate_slot_reverse",
+		new_mod_name..":"..new_material_name.."_gate_slot_reverse"
+	)
 end
-castle_gates.register_gate_slot_alias_force = function(old_mod_name, old_material_name, new_mod_name, new_material_name)
-	minetest.register_alias_force(old_mod_name..":"..old_material_name.."_gate_slot",			new_mod_name..":"..new_material_name.."_gate_slot")
-	minetest.register_alias_force(old_mod_name..":"..old_material_name.."_gate_slot_reverse",	new_mod_name..":"..new_material_name.."_gate_slot_reverse")
+function castle_gates.register_gate_slot_alias_force(old_mod_name, old_material_name, new_mod_name, new_material_name)
+	minetest.register_alias_force(
+		old_mod_name..":"..old_material_name.."_gate_slot",
+		new_mod_name..":"..new_material_name.."_gate_slot"
+	)
+	minetest.register_alias_force(
+		old_mod_name..":"..old_material_name.."_gate_slot_reverse",
+		new_mod_name..":"..new_material_name.."_gate_slot_reverse"
+	)
 end
 
 for _, material in pairs(materials) do

--- a/gates.lua
+++ b/gates.lua
@@ -1,276 +1,281 @@
 local S = minetest.get_translator("castle_gates")
 
-minetest.register_alias("castle_gates:gate_edge",				"castle_gates:wood_gate_edge")
-minetest.register_alias("castle_gates:gate_edge_handle",		"castle_gates:wood_gate_edge_handle")
-minetest.register_alias("castle_gates:gate_hinge",				"castle_gates:wood_gate_hinge")
-minetest.register_alias("castle_gates:gate_panel",				"castle_gates:wood_gate_panel")
-minetest.register_alias("castle_gates:portcullis_bars",			"castle_gates:wood_portcullis_bars")
-minetest.register_alias("castle_gates:portcullis_bars_bottom",	"castle_gates:wood_portcullis_bars_bottom")
+minetest.register_alias("castle_gates:gate_edge", "castle_gates:wood_gate_edge")
+minetest.register_alias("castle_gates:gate_edge_handle", "castle_gates:wood_gate_edge_handle")
+minetest.register_alias("castle_gates:gate_hinge", "castle_gates:wood_gate_hinge")
+minetest.register_alias("castle_gates:gate_panel", "castle_gates:wood_gate_panel")
+minetest.register_alias("castle_gates:portcullis_bars", "castle_gates:wood_portcullis_bars")
+minetest.register_alias("castle_gates:portcullis_bars_bottom", "castle_gates:wood_portcullis_bars_bottom")
 
-local register_gates = function(node_prefix, material_description, material_texture, gate_groups, gate_sounds, portcullis_recipe, panel_recipe)
+local function register_gates(
+    node_prefix, material_description, material_texture, gate_groups, gate_sounds, portcullis_recipe, panel_recipe
+)
+    local portcullis_groups = { castle_gate = 1, flow_through = 1 }
+    local panel_groups = { castle_gate = 1 }
+    for group, val in pairs(gate_groups) do
+        portcullis_groups[group] = val
+        panel_groups[group] = val
+    end
 
-local portcullis_groups = {castle_gate = 1, flow_through = 1}
-local panel_groups = {castle_gate = 1}
-for group, val in pairs(gate_groups) do
-	portcullis_groups[group] = val
-	panel_groups[group] = val
+    minetest.register_node("castle_gates:" .. node_prefix .. "_portcullis_bars", {
+        drawtype = "nodebox",
+        description = S("@1 Portcullis Bars", material_description),
+        _doc_items_longdesc = castle_gates.doc.portcullis_bars_longdesc,
+        _doc_items_usagehelp = castle_gates.doc.portcullis_bars_usagehelp,
+        groups = portcullis_groups,
+        tiles = {
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+        },
+        sounds = gate_sounds,
+        paramtype = "light",
+        paramtype2 = "facedir",
+        node_box = {
+            type = "fixed",
+            fixed = {
+                { -0.125, -0.5, -0.5, 0.125, 0.5, -0.25 }, -- middle bar
+                { -0.5, -0.5, -0.5, -0.375, 0.5, -0.25 }, -- side bar
+                { 0.375, -0.5, -0.5, 0.5, 0.5, -0.25 }, -- side bar
+                { -0.375, 0.1875, -0.4375, 0.375, 0.3125, -0.3125 }, -- crosspiece
+                { -0.375, -0.3125, -0.4375, 0.375, -0.1875, -0.3125 }, -- crosspiece
+            }
+        },
+        on_rightclick = castle_gates.trigger_gate,
+    })
+
+    minetest.register_node("castle_gates:" .. node_prefix .. "_portcullis_bars_bottom", {
+        drawtype = "nodebox",
+        description = S("@1 Portcullis Bottom", material_description),
+        _doc_items_longdesc = castle_gates.doc.portcullis_bars_bottom_longdesc,
+        _doc_items_usagehelp = castle_gates.doc.portcullis_bars_bottom_usagehelp,
+        groups = portcullis_groups,
+        tiles = {
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_portcullis_mask.png)",
+        },
+        sounds = gate_sounds,
+        paramtype = "light",
+        paramtype2 = "facedir",
+        node_box = {
+            type = "fixed",
+            fixed = {
+                { -0.125, -0.5, -0.5, 0.125, 0.5, -0.25 }, -- middle bar
+                { -0.5, -0.5, -0.5, -0.375, 0.5, -0.25 }, -- side bar
+                { 0.375, -0.5, -0.5, 0.5, 0.5, -0.25 }, -- side bar
+                { -0.375, 0.1875, -0.4375, 0.375, 0.3125, -0.3125 }, -- crosspiece
+                { -0.375, -0.3125, -0.4375, 0.375, -0.1875, -0.3125 }, -- crosspiece
+                { -0.0625, -0.5, -0.4375, 0.0625, -0.625, -0.3125 }, -- peg
+                { 0.4375, -0.5, -0.4375, 0.5, -0.625, -0.3125 }, -- peg
+                { -0.5, -0.5, -0.4375, -0.4375, -0.625, -0.3125 }, -- peg
+            }
+        },
+        _gate_edges = { bottom = true },
+        on_rightclick = castle_gates.trigger_gate,
+    })
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_portcullis_bars 3",
+        recipe = portcullis_recipe,
+    })
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_portcullis_bars",
+        recipe = {
+            { "castle_gates:" .. node_prefix .. "_portcullis_bars_bottom" }
+        },
+    })
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_portcullis_bars_bottom",
+        recipe = {
+            { "castle_gates:" .. node_prefix .. "_portcullis_bars" }
+        },
+    })
+
+    --------------------------------------------------------------------------------------------------------------
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_gate_panel 8",
+        recipe = panel_recipe,
+    })
+
+    minetest.register_node("castle_gates:" .. node_prefix .. "_gate_panel", {
+        drawtype = "nodebox",
+        description = S("@1 Gate Door", material_description),
+        _doc_items_longdesc = castle_gates.doc.gate_panel_longdesc,
+        _doc_items_usagehelp = castle_gates.doc.gate_panel_usagehelp,
+        groups = panel_groups,
+        tiles = {
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+        },
+        sounds = gate_sounds,
+        paramtype = "light",
+        paramtype2 = "facedir",
+        node_box = {
+            type = "fixed",
+            fixed = {
+                { -0.5, -0.5, -0.5, 0.5, 0.5, -0.25 },
+            }
+        },
+        on_rightclick = castle_gates.trigger_gate,
+    })
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_gate_edge",
+        type = "shapeless",
+        recipe = { "castle_gates:" .. node_prefix .. "_gate_panel" },
+    })
+
+    minetest.register_node("castle_gates:" .. node_prefix .. "_gate_edge", {
+        drawtype = "nodebox",
+        description = S("@1 Gate Door Edge", material_description),
+        _doc_items_longdesc = castle_gates.doc.gate_edge_longdesc,
+        _doc_items_usagehelp = castle_gates.doc.gate_edge_usagehelp,
+        groups = panel_groups,
+        tiles = {
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90",
+            material_texture .. "^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png^[transformFX)",
+            material_texture .. "^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png)",
+        },
+        sounds = gate_sounds,
+        paramtype = "light",
+        paramtype2 = "facedir",
+        node_box = {
+            type = "fixed",
+            fixed = {
+                { -0.5, -0.5, -0.5, 0.5, 0.5, -0.25 },
+            }
+        },
+        _gate_edges = { right = true },
+        on_rightclick = castle_gates.trigger_gate,
+    })
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_gate_edge_handle",
+        type = "shapeless",
+        recipe = { "castle_gates:" .. node_prefix .. "_gate_edge" },
+    })
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_gate_panel",
+        type = "shapeless",
+        recipe = { "castle_gates:" .. node_prefix .. "_gate_edge_handle" },
+    })
+
+    minetest.register_node("castle_gates:" .. node_prefix .. "_gate_edge_handle", {
+        drawtype = "nodebox",
+        description = S("@1 Gate Door With Handle", material_description),
+        _doc_items_longdesc = castle_gates.doc.gate_edge_handle_longdesc,
+        _doc_items_usagehelp = castle_gates.doc.gate_edge_handle_usagehelp,
+        groups = panel_groups,
+        tiles = {
+            "castle_steel.png^(" .. material_texture .. "^[mask:castle_door_side_mask.png^[transformR90)",
+            "castle_steel.png^(" .. material_texture .. "^[mask:castle_door_side_mask.png^[transformR270)",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:castle_door_side_mask.png)",
+            "castle_steel.png^(" .. material_texture .. "^[transformR90^[mask:(castle_door_side_mask.png" ..
+                "^[transformFX))",
+            material_texture .. "^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png" ..
+                "^[transformFX)^(castle_steel.png^[mask:castle_door_handle_mask.png^[transformFX)",
+            material_texture .. "^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png)" ..
+                "^(castle_steel.png^[mask:castle_door_handle_mask.png)",
+        },
+        sounds = gate_sounds,
+        paramtype = "light",
+        paramtype2 = "facedir",
+        node_box = {
+            type = "fixed",
+            fixed = {
+                { -0.5, -0.5, -0.5, 0.5, 0.5, -0.25 },
+                { 4 / 16, -4 / 16, -2 / 16, 6 / 16, 4 / 16, -3 / 16 },
+                { 4 / 16, -4 / 16, -9 / 16, 6 / 16, 4 / 16, -10 / 16 },
+                { 4 / 16, -4 / 16, -9 / 16, 6 / 16, -3 / 16, -3 / 16 },
+                { 4 / 16, 4 / 16, -9 / 16, 6 / 16, 3 / 16, -3 / 16 },
+            }
+        },
+        _gate_edges = { right = true },
+        on_rightclick = castle_gates.trigger_gate,
+    })
+
+
+    ------------------------------------------------------------------------------
+
+    minetest.register_craft({
+        output = "castle_gates:" .. node_prefix .. "_gate_hinge 3",
+        recipe = {
+            { "", "castle_gates:" .. node_prefix .. "_gate_panel", "" },
+            { "default:steel_ingot", "castle_gates:" .. node_prefix .. "_gate_panel", "" },
+            { "", "castle_gates:" .. node_prefix .. "_gate_panel", "" }
+        },
+    })
+
+    minetest.register_node("castle_gates:" .. node_prefix .. "_gate_hinge", {
+        drawtype = "nodebox",
+        description = S("@1 Gate Door With Hinge", material_description),
+        _doc_items_longdesc = castle_gates.doc.gate_hinge_longdesc,
+        _doc_items_usagehelp = castle_gates.doc.gate_hinge_usagehelp,
+        groups = panel_groups,
+        tiles = {
+            material_texture .. "^[transformR90",
+        },
+        sounds = gate_sounds,
+        paramtype = "light",
+        paramtype2 = "facedir",
+
+        node_box = {
+            type = "fixed",
+            fixed = {
+                { -0.5, -0.5, -0.5, 0.5, 0.5, -0.25 },
+                { -10 / 16, -4 / 16, -10 / 16, -6 / 16, 4 / 16, -6 / 16 },
+            }
+        },
+        collision_box = {
+            type = "fixed",
+            fixed = { -0.5, -0.5, -0.5, 0.5, 0.5, -0.25 },
+        },
+
+        _gate_hinge = { axis = "top", offset = { "front", "left" } },
+        on_rightclick = castle_gates.trigger_gate,
+    })
+
 end
 
-minetest.register_node("castle_gates:"..node_prefix.."_portcullis_bars", {
-	drawtype = "nodebox",
-	description = S("@1 Portcullis Bars", material_description),
-	_doc_items_longdesc = castle_gates.doc.portcullis_bars_longdesc,
-	_doc_items_usagehelp = castle_gates.doc.portcullis_bars_usagehelp,
-	groups = portcullis_groups,
-	tiles = {
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		},
-	sounds = gate_sounds,
-	paramtype = "light",
-	paramtype2 = "facedir",
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.125, -0.5, -0.5, 0.125, 0.5, -0.25}, -- middle bar
-			{-0.5, -0.5, -0.5, -0.375, 0.5, -0.25}, -- side bar
-			{0.375, -0.5, -0.5, 0.5, 0.5, -0.25}, -- side bar
-			{-0.375, 0.1875, -0.4375, 0.375, 0.3125, -0.3125}, -- crosspiece
-			{-0.375, -0.3125, -0.4375, 0.375, -0.1875, -0.3125}, -- crosspiece
-		}
-	},
-	on_rightclick = castle_gates.trigger_gate,
-})
-
-minetest.register_node("castle_gates:"..node_prefix.."_portcullis_bars_bottom", {
-	drawtype = "nodebox",
-	description = S("@1 Portcullis Bottom", material_description),
-	_doc_items_longdesc = castle_gates.doc.portcullis_bars_bottom_longdesc,
-	_doc_items_usagehelp = castle_gates.doc.portcullis_bars_bottom_usagehelp,
-	groups = portcullis_groups,
-	tiles = {
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_portcullis_mask.png)",
-		},
-	sounds = gate_sounds,
-	paramtype = "light",
-	paramtype2 = "facedir",
-		node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.125, -0.5, -0.5, 0.125, 0.5, -0.25}, -- middle bar
-			{-0.5, -0.5, -0.5, -0.375, 0.5, -0.25}, -- side bar
-			{0.375, -0.5, -0.5, 0.5, 0.5, -0.25}, -- side bar
-			{-0.375, 0.1875, -0.4375, 0.375, 0.3125, -0.3125}, -- crosspiece
-			{-0.375, -0.3125, -0.4375, 0.375, -0.1875, -0.3125}, -- crosspiece
-			{-0.0625, -0.5, -0.4375, 0.0625, -0.625, -0.3125}, -- peg
-			{0.4375, -0.5, -0.4375, 0.5, -0.625, -0.3125}, -- peg
-			{-0.5, -0.5, -0.4375, -0.4375, -0.625, -0.3125}, -- peg
-		}
-	},
-	_gate_edges = {bottom=true},
-	on_rightclick = castle_gates.trigger_gate,
-})
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_portcullis_bars 3",
-	recipe = portcullis_recipe,
-})
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_portcullis_bars",
-	recipe = {
-		{"castle_gates:"..node_prefix.."_portcullis_bars_bottom"}
-	},
-})
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_portcullis_bars_bottom",
-	recipe = {
-		{"castle_gates:"..node_prefix.."_portcullis_bars"}
-	},
-})
-
---------------------------------------------------------------------------------------------------------------
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_gate_panel 8",
-	recipe = panel_recipe,
-})
-
-minetest.register_node("castle_gates:"..node_prefix.."_gate_panel", {
-	drawtype = "nodebox",
-	description = S("@1 Gate Door", material_description),
-	_doc_items_longdesc = castle_gates.doc.gate_panel_longdesc,
-	_doc_items_usagehelp = castle_gates.doc.gate_panel_usagehelp,
-	groups = panel_groups,
-	tiles = {
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		},
-	sounds = gate_sounds,
-	paramtype = "light",
-	paramtype2 = "facedir",
-		node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.5, -0.5, -0.5, 0.5, 0.5, -0.25},
-		}
-	},
-	on_rightclick = castle_gates.trigger_gate,
-})
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_gate_edge",
-	type = "shapeless",
-	recipe = {"castle_gates:"..node_prefix.."_gate_panel"},
-})
-
-minetest.register_node("castle_gates:"..node_prefix.."_gate_edge", {
-	drawtype = "nodebox",
-	description = S("@1 Gate Door Edge", material_description),
-	_doc_items_longdesc = castle_gates.doc.gate_edge_longdesc,
-	_doc_items_usagehelp = castle_gates.doc.gate_edge_usagehelp,
-	groups = panel_groups,
-	tiles = {
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90",
-		material_texture.."^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png^[transformFX)",
-		material_texture.."^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png)",
-		},
-	sounds = gate_sounds,
-	paramtype = "light",
-	paramtype2 = "facedir",
-		node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.5, -0.5, -0.5, 0.5, 0.5, -0.25},
-		}
-	},
-	_gate_edges = {right=true},
-	on_rightclick = castle_gates.trigger_gate,
-})
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_gate_edge_handle",
-	type = "shapeless",
-	recipe = {"castle_gates:"..node_prefix.."_gate_edge"},
-})
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_gate_panel",
-	type = "shapeless",
-	recipe = {"castle_gates:"..node_prefix.."_gate_edge_handle"},
-})
-
-minetest.register_node("castle_gates:"..node_prefix.."_gate_edge_handle", {
-	drawtype = "nodebox",
-	description = S("@1 Gate Door With Handle", material_description),
-	_doc_items_longdesc = castle_gates.doc.gate_edge_handle_longdesc,
-	_doc_items_usagehelp = castle_gates.doc.gate_edge_handle_usagehelp,
-	groups = panel_groups,
-	tiles = {
-		"castle_steel.png^("..material_texture.."^[mask:castle_door_side_mask.png^[transformR90)",
-		"castle_steel.png^("..material_texture.."^[mask:castle_door_side_mask.png^[transformR270)",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:castle_door_side_mask.png)",
-		"castle_steel.png^("..material_texture.."^[transformR90^[mask:(castle_door_side_mask.png^[transformFX))",
-		material_texture.."^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png^[transformFX)^(castle_steel.png^[mask:castle_door_handle_mask.png^[transformFX)",
-		material_texture.."^[transformR90^(default_coal_block.png^[mask:castle_door_edge_mask.png)^(castle_steel.png^[mask:castle_door_handle_mask.png)",
-		},
-	sounds = gate_sounds,
-	paramtype = "light",
-	paramtype2 = "facedir",
-		node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.5, -0.5, -0.5, 0.5, 0.5, -0.25},
-			{4/16, -4/16, -2/16, 6/16, 4/16, -3/16},
-			{4/16, -4/16, -9/16, 6/16, 4/16, -10/16},
-			{4/16, -4/16, -9/16, 6/16, -3/16, -3/16},
-			{4/16, 4/16, -9/16, 6/16, 3/16, -3/16},
-		}
-	},
-	_gate_edges = {right=true},
-	on_rightclick = castle_gates.trigger_gate,
-})
-
-
-------------------------------------------------------------------------------
-
-minetest.register_craft({
-	output = "castle_gates:"..node_prefix.."_gate_hinge 3",
-	recipe = {
-		{"", "castle_gates:"..node_prefix.."_gate_panel", ""},
-		{"default:steel_ingot", "castle_gates:"..node_prefix.."_gate_panel", ""},
-		{"", "castle_gates:"..node_prefix.."_gate_panel", ""}
-	},
-})
-
-minetest.register_node("castle_gates:"..node_prefix.."_gate_hinge", {
-	drawtype = "nodebox",
-	description = S("@1 Gate Door With Hinge", material_description),
-	_doc_items_longdesc = castle_gates.doc.gate_hinge_longdesc,
-	_doc_items_usagehelp = castle_gates.doc.gate_hinge_usagehelp,
-	groups = panel_groups,
-	tiles = {
-		material_texture.."^[transformR90",
-		},
-	sounds = gate_sounds,
-	paramtype = "light",
-	paramtype2 = "facedir",
-	
-	node_box = {
-		type = "fixed",
-		fixed = {
-			{-0.5, -0.5, -0.5, 0.5, 0.5, -0.25},
-			{-10/16, -4/16, -10/16, -6/16, 4/16, -6/16},
-		}
-	},
-	collision_box = {
-		type = "fixed",
-		fixed = {-0.5, -0.5, -0.5, 0.5, 0.5, -0.25},
-	},
-	
-	_gate_hinge = {axis="top", offset={"front","left"}},
-	on_rightclick = castle_gates.trigger_gate,
-})
-
-end
-
-register_gates("wood", S("Wooden"), "default_wood.png", {choppy = 1}, default.node_sound_wood_defaults(),
-	{
-		{"group:wood","default:steel_ingot","group:wood" },
-		{"group:wood","default:steel_ingot","group:wood" },
-		{"group:wood","default:steel_ingot","group:wood" },
-	},
-	{
-		{"stairs:slab_wood","stairs:slab_wood", ""},
-		{"stairs:slab_wood","stairs:slab_wood", ""},
-	}
+register_gates("wood", S("Wooden"), "default_wood.png", { choppy = 1 }, default.node_sound_wood_defaults(),
+    {
+        { "group:wood", "default:steel_ingot", "group:wood" },
+        { "group:wood", "default:steel_ingot", "group:wood" },
+        { "group:wood", "default:steel_ingot", "group:wood" },
+    },
+    {
+        { "stairs:slab_wood", "stairs:slab_wood", "" },
+        { "stairs:slab_wood", "stairs:slab_wood", "" },
+    }
 )
 
-register_gates("steel", S("Steel"), "default_steel_block.png", {cracky = 1, level = 2}, default.node_sound_metal_defaults(),
-	{
-		{"","default:steel_ingot","" },
-		{"default:steel_ingot","default:steel_ingot","default:steel_ingot" },
-		{"","default:steel_ingot","" },
-	},
-	{
-		{"stairs:slab_steelblock","stairs:slab_steelblock", ""},
-		{"stairs:slab_steelblock","stairs:slab_steelblock", ""},
-	}
+register_gates("steel", S("Steel"), "default_steel_block.png", { cracky = 1, level = 2 },
+    default.node_sound_metal_defaults(),
+    {
+        { "", "default:steel_ingot", "" },
+        { "default:steel_ingot", "default:steel_ingot", "default:steel_ingot" },
+        { "", "default:steel_ingot", "" },
+    },
+    {
+        { "stairs:slab_steelblock", "stairs:slab_steelblock", "" },
+        { "stairs:slab_steelblock", "stairs:slab_steelblock", "" },
+    }
 )


### PR DESCRIPTION
All nodes of type `castle_gates:*_gate_slot` have their hitbox oriented wrong compared to the visual. You can jump into part of them, but can't pass through the empty area on the other side.

You can even use this to create an "invisible bridge".

![image](https://user-images.githubusercontent.com/25628292/167276306-e1744c7c-e028-43f5-9a32-bef513109c6f.png)

This PR also includes automated .luacheck-ing