### PR TITLE
fix crash caused by unknown nodes

### DIFF
--- a/gate_functions.lua
+++ b/gate_functions.lua
@@ -291,9 +291,7 @@ local get_door_layout = function(pos, facedir, player)
 				if not vector.equals(door_node.pos, origin) then
 					-- There's no obstruction if the node is literally located along the rotation axis
 					local newpos = rotate_pos_displaced(door_node.pos, origin, axis, direction)
-					local newnode = minetest.get_node(newpos)
-					local newdef = minetest.registered_nodes[newnode.name]
-					if not (newdef and newdef.buildable_to) then
+					if get_buildable_to(newpos) then
 						-- check if the destination node is free.
 						door.swings[direction] = false
 						break

--- a/gate_functions.lua
+++ b/gate_functions.lua
@@ -114,7 +114,8 @@ local rotate_pos_displaced = function(pos, origin, axis, direction)
 end
 
 local get_buildable_to = function(pos)
-	return minetest.registered_nodes[minetest.get_node(pos).name].buildable_to
+	local def = minetest.registered_nodes[minetest.get_node(pos).name]
+	return def and def.buildable_to
 end
 
 
@@ -292,7 +293,7 @@ local get_door_layout = function(pos, facedir, player)
 					local newpos = rotate_pos_displaced(door_node.pos, origin, axis, direction)
 					local newnode = minetest.get_node(newpos)
 					local newdef = minetest.registered_nodes[newnode.name]
-					if not newdef.buildable_to then
+					if not (newdef and newdef.buildable_to) then
 						-- check if the destination node is free.
 						door.swings[direction] = false
 						break


### PR DESCRIPTION
there are missing nil checks for `minetest.registered_nodes[something]`

If you look closely, you can see that there is one place left:
https://github.com/minetest-mods/castle_gates/blob/8449b54203674608736498e4f48d625874a874a5/gate_functions.lua#L165-L166

As far as I can see, this one should already be covered by the check on L217.
But I can add one for good measure if wanted.